### PR TITLE
feat: add schema-based guild config handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .env
+/config

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "chalk": "^5.5.0",
         "discord.js": "^14.21.0",
-        "dotenv": "^17.2.1"
+        "dotenv": "^17.2.1",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/chalk": "^0.4.31",
@@ -904,6 +905,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "chalk": "^5.5.0",
     "discord.js": "^14.21.0",
-    "dotenv": "^17.2.1"
+    "dotenv": "^17.2.1",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/chalk": "^0.4.31",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import { Client, GatewayIntentBits } from 'discord.js';
 import { logger } from './lib/logger';
+import { configManager } from './lib/config';
 
 const token = process.env.DISCORD_TOKEN;
 if (!token) {
@@ -12,8 +13,12 @@ const client = new Client({
     intents: [GatewayIntentBits.Guilds],
 });
 
-client.once('ready', () => {
+client.once('ready', async () => {
     logger.info(`✅ Logged in as ${client.user?.tag}`);
+    await configManager.loadSchemas();
+    for (const guild of client.guilds.cache.values()) {
+        await configManager.get(guild.id);
+    }
 });
 
 client.login(token).catch((e) => {

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import type { ConfigSchema, GuildConfig } from './types.js';
+import { logger } from '../logger.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeDeep(base: any, updates: any): any {
+    const result: any = { ...base };
+    for (const key of Object.keys(updates)) {
+        const baseVal = result[key];
+        const updateVal = updates[key];
+        if (isObject(baseVal) && isObject(updateVal)) {
+            result[key] = mergeDeep(baseVal, updateVal);
+        } else {
+            result[key] = updateVal;
+        }
+    }
+    return result;
+}
+
+export class ConfigManager {
+    private schemas = new Map<string, ConfigSchema<any>>();
+    private cache = new Map<string, GuildConfig>();
+    private configDir: string;
+    private schemaDir: string;
+
+    constructor(options?: { configDir?: string; schemaDir?: string }) {
+        this.configDir = options?.configDir || path.join(process.cwd(), 'config');
+        this.schemaDir = options?.schemaDir || path.join(__dirname, 'schemas');
+    }
+
+    async loadSchemas() {
+        const files = await fs.readdir(this.schemaDir);
+        for (const file of files) {
+            if (!file.endsWith('.js') && !file.endsWith('.ts')) continue;
+            const fileUrl = pathToFileURL(path.join(this.schemaDir, file)).href;
+            const mod = await import(fileUrl);
+            const schema: ConfigSchema<any> = mod.default || mod.schema;
+            if (schema && schema.key) {
+                this.schemas.set(schema.key, schema);
+                logger.info(`Loaded config schema: ${schema.key}`);
+            }
+        }
+    }
+
+    private async ensureDir() {
+        await fs.mkdir(this.configDir, { recursive: true });
+    }
+
+    async get(guildId: string): Promise<GuildConfig> {
+        if (this.cache.has(guildId)) {
+            return this.cache.get(guildId)!;
+        }
+        await this.ensureDir();
+        const filePath = path.join(this.configDir, `${guildId}.json`);
+        let data: GuildConfig = {};
+        try {
+            const raw = await fs.readFile(filePath, 'utf8');
+            data = JSON.parse(raw);
+        } catch {
+            // file does not exist yet
+        }
+        for (const [key, schema] of this.schemas) {
+            const current = data[key] as any;
+            const merged = mergeDeep(schema.default, isObject(current) ? current : {});
+            try {
+                data[key] = schema.schema.parse(merged);
+            } catch {
+                data[key] = schema.default;
+            }
+        }
+        await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf8');
+        this.cache.set(guildId, data);
+        return data;
+    }
+
+    async set(guildId: string, key: string, value: unknown) {
+        const config = await this.get(guildId);
+        config[key] = value;
+        await fs.writeFile(path.join(this.configDir, `${guildId}.json`), JSON.stringify(config, null, 2), 'utf8');
+        this.cache.set(guildId, config);
+    }
+}
+
+export const configManager = new ConfigManager();

--- a/src/lib/config/schemas/general.ts
+++ b/src/lib/config/schemas/general.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import type { ConfigSchema } from '../types.js';
+
+const schema: ConfigSchema<{ prefix: string }> = {
+    key: 'general',
+    schema: z.object({
+        prefix: z.string(),
+    }),
+    default: {
+        prefix: '!',
+    },
+};
+
+export default schema;

--- a/src/lib/config/types.ts
+++ b/src/lib/config/types.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export interface ConfigSchema<T> {
+    key: string;
+    schema: z.ZodType<T>;
+    default: T;
+}
+
+export type GuildConfig = Record<string, unknown>;


### PR DESCRIPTION
## Summary
- add zod-based config manager with per-guild JSON files
- load shared schemas and merge defaults on startup
- initialize configs for joined guilds

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68975d86c8648321838211e3f8dfaf62