### PR TITLE
feat: add slash command handler

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,23 @@
+import { SlashCommandBuilder } from 'discord.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { configManager } from '../lib/config/index.js';
+import type { Command } from './types.js';
+
+const command: Command = {
+    data: new SlashCommandBuilder()
+        .setName('config')
+        .setDescription('Zeigt die Serverkonfiguration an'),
+    async execute(interaction: ChatInputCommandInteraction) {
+        if (!interaction.guildId) {
+            await interaction.reply({ content: 'Dieser Befehl kann nur auf einem Server verwendet werden.', ephemeral: true });
+            return;
+        }
+        const config = await configManager.get(interaction.guildId);
+        await interaction.reply({
+            content: `\`\`\`json\n${JSON.stringify(config, null, 2)}\n\`\`\``,
+            ephemeral: true,
+        });
+    },
+};
+
+export default command;

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,20 @@
+import { SlashCommandBuilder, EmbedBuilder } from 'discord.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import type { Command } from './types.js';
+
+const command: Command = {
+    data: new SlashCommandBuilder()
+        .setName('help')
+        .setDescription('Zeigt eine Übersicht aller verfügbaren Befehle'),
+    async execute(interaction: ChatInputCommandInteraction) {
+        const { commands } = await import('./index.js');
+        const embed = new EmbedBuilder()
+            .setTitle('Verfügbare Befehle');
+        for (const cmd of commands) {
+            embed.addFields({ name: `/${cmd.data.name}`, value: cmd.data.description || 'Keine Beschreibung' });
+        }
+        await interaction.reply({ embeds: [embed], ephemeral: true });
+    },
+};
+
+export default command;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,5 @@
+import type { Command } from './types.js';
+import config from './config.js';
+import help from './help.js';
+
+export const commands: Command[] = [config, help];

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,7 @@
+import type { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+
+export interface Command {
+    data: SlashCommandBuilder;
+    execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import 'dotenv/config';
 import { Client, GatewayIntentBits } from 'discord.js';
-import { logger } from './lib/logger';
-import { configManager } from './lib/config';
+import { logger } from './lib/logger.js';
+import { configManager } from './lib/config/index.js';
+import { commands } from './commands/index.js';
 
 const token = process.env.DISCORD_TOKEN;
 if (!token) {
@@ -18,6 +19,25 @@ client.once('ready', async () => {
     await configManager.loadSchemas();
     for (const guild of client.guilds.cache.values()) {
         await configManager.get(guild.id);
+    }
+    await client.application?.commands.set(commands.map((c) => c.data.toJSON()));
+    logger.info('✅ Slash commands registered');
+});
+
+client.on('interactionCreate', async (interaction) => {
+    if (!interaction.isChatInputCommand()) return;
+    const command = commands.find((c) => c.data.name === interaction.commandName);
+    if (!command) return;
+    try {
+        await command.execute(interaction);
+    } catch (error) {
+        logger.error('❌ Error executing command:', error);
+        const reply = { content: 'Es ist ein Fehler aufgetreten.', ephemeral: true } as const;
+        if (interaction.deferred || interaction.replied) {
+            await interaction.followUp(reply);
+        } else {
+            await interaction.reply(reply);
+        }
     }
 });
 


### PR DESCRIPTION
## Summary
- add config slash command
- add help slash command with embed listing commands
- register slash commands and interaction handling

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68976071ac608321bf2d3298c9ffe57d