### PR TITLE
fix: split housing config rows

### DIFF
--- a/src/commands/config/housingConfig.ts
+++ b/src/commands/config/housingConfig.ts
@@ -138,9 +138,10 @@ async function handle(interaction: ChatInputCommandInteraction) {
       .setLabel("Cancel")
       .setStyle(ButtonStyle.Secondary),
   );
-
+  // Discord limits messages to 5 action rows, so we split the reply
+  // into two messages to avoid hitting the limit.
   await interaction.reply({
-  content: summaryContent({
+    content: summaryContent({
       enabled: Boolean(h.enabled),
       dc,
       world,
@@ -151,7 +152,13 @@ async function handle(interaction: ChatInputCommandInteraction) {
       pingUserId: h.pingUserId,
       pingRoleId: h.pingRoleId,
     }),
-    components: [dcRow, worldRow, distRow, chRow, userRow, roleRow, btnRow],
+    components: [dcRow, worldRow, distRow, chRow, userRow],
+    flags: MessageFlags.Ephemeral,
+  });
+
+  await interaction.followUp({
+    content: 'Weitere Optionen:',
+    components: [roleRow, btnRow],
     flags: MessageFlags.Ephemeral,
   });
     } catch (err) {

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -14,8 +14,9 @@ export function register(client: Client) {
         for (const guild of client.guilds.cache.values()) {
             await configManager.get(guild.id);
         }
+        // Refresh slash commands on every startup so Discord has the latest data
         await commandHandler.deploy(client);
-        logger.info('✅ Commands registered');
+        logger.info('✅ Commands registered (refreshed)');
     });
 }
 


### PR DESCRIPTION
## Summary
- split housing config UI across two messages so each stays under Discord's 5-row limit
- refresh slash commands on startup

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6898e450cc9c8321a6122081cd0b6ee4