### PR TITLE
Add housing interaction handler

### DIFF
--- a/src/events/housing/housingInteraction.ts
+++ b/src/events/housing/housingInteraction.ts
@@ -1,0 +1,164 @@
+import { Client, Events, MessageFlags } from 'discord.js';
+import { HOUSING_PREFIX } from '../../commands/config/housingConfig.js';
+import { uiKey, setDraft, getDraft, clearDraft } from '../../ui/housingUI.js';
+import { configManager } from '../../lib/config/configHandler.js';
+import { logger } from '../../lib/logger.js';
+
+/**
+ * Handles all interactions related to the housing configuration UI.
+ */
+export function register(client: Client) {
+    client.on(Events.InteractionCreate, async (interaction) => {
+        try {
+            if (
+                !(interaction.isButton() ||
+                  interaction.isStringSelectMenu() ||
+                  interaction.isChannelSelectMenu() ||
+                  interaction.isUserSelectMenu() ||
+                  interaction.isRoleSelectMenu())
+            ) {
+                return;
+            }
+
+            const customId = interaction.customId ?? '';
+            if (!customId.startsWith(HOUSING_PREFIX) || !interaction.guildId) {
+                return;
+            }
+
+            const action = customId.slice(HOUSING_PREFIX.length);
+            const key = uiKey(interaction.guildId, interaction.user.id);
+
+            switch (action) {
+                case 'dc':
+                    if (interaction.isStringSelectMenu()) {
+                        const dc = interaction.values[0]!;
+                        setDraft(key, { dataCenter: dc });
+                        await interaction.reply({
+                            content: `Datacenter auf **${dc}** gesetzt.`,
+                            flags: MessageFlags.Ephemeral,
+                        });
+                    }
+                    break;
+                case 'world':
+                    if (interaction.isStringSelectMenu()) {
+                        const world = interaction.values[0]!;
+                        setDraft(key, { world });
+                        await interaction.reply({
+                            content: `World auf **${world}** gesetzt.`,
+                            flags: MessageFlags.Ephemeral,
+                        });
+                    }
+                    break;
+                case 'districts':
+                    if (interaction.isStringSelectMenu()) {
+                        const districts = interaction.values;
+                        setDraft(key, { districts });
+                        await interaction.reply({
+                            content: `Districts aktualisiert.`,
+                            flags: MessageFlags.Ephemeral,
+                        });
+                    }
+                    break;
+                case 'channel':
+                    if (interaction.isChannelSelectMenu()) {
+                        const channel = interaction.channels.first();
+                        const patch: any = channel ? { channelId: channel.id } : { channelId: undefined };
+                        setDraft(key, patch);
+                        await interaction.reply({
+                            content: channel ? `Kanal auf <#${channel.id}> gesetzt.` : 'Kanal entfernt.',
+                            flags: MessageFlags.Ephemeral,
+                        });
+                    }
+                    break;
+                case 'pinguser':
+                    if (interaction.isUserSelectMenu()) {
+                        const user = interaction.users.first();
+                        const patch: any = user ? { pingUserId: user.id } : { pingUserId: undefined };
+                        setDraft(key, patch);
+                        await interaction.reply({
+                            content: user ? `Ping-User auf <@${user.id}> gesetzt.` : 'Ping-User entfernt.',
+                            flags: MessageFlags.Ephemeral,
+                        });
+                    }
+                    break;
+                case 'pingrole':
+                    if (interaction.isRoleSelectMenu()) {
+                        const role = interaction.roles.first();
+                        const patch: any = role ? { pingRoleId: role.id } : { pingRoleId: undefined };
+                        setDraft(key, patch);
+                        await interaction.reply({
+                            content: role ? `Ping-Rolle auf <@&${role.id}> gesetzt.` : 'Ping-Rolle entfernt.',
+                            flags: MessageFlags.Ephemeral,
+                        });
+                    }
+                    break;
+                case 'toggle':
+                    if (interaction.isButton()) {
+                        const current = getDraft(key)?.enabled ?? false;
+                        const draft = setDraft(key, { enabled: !current });
+                        await interaction.reply({
+                            content: `Housing ist jetzt ${draft.enabled ? 'aktiviert' : 'deaktiviert'}.`,
+                            flags: MessageFlags.Ephemeral,
+                        });
+                    }
+                    break;
+                case 'schedule':
+                    if (interaction.isButton()) {
+                        await interaction.reply({
+                            content: 'Planung noch nicht implementiert.',
+                            flags: MessageFlags.Ephemeral,
+                        });
+                    }
+                    break;
+                case 'save':
+                    if (interaction.isButton()) {
+                        const draft = getDraft(key);
+                        if (draft) {
+                            await configManager.update(interaction.guildId, 'housing', draft);
+                            clearDraft(key);
+                            await interaction.reply({
+                                content: 'Housing-Konfiguration gespeichert.',
+                                flags: MessageFlags.Ephemeral,
+                            });
+                        } else {
+                            await interaction.reply({
+                                content: 'Keine Änderungen zum Speichern.',
+                                flags: MessageFlags.Ephemeral,
+                            });
+                        }
+                    }
+                    break;
+                case 'cancel':
+                    if (interaction.isButton()) {
+                        clearDraft(key);
+                        await interaction.reply({
+                            content: 'Änderungen verworfen.',
+                            flags: MessageFlags.Ephemeral,
+                        });
+                    }
+                    break;
+                default:
+                    logger.warn(`Unhandled housing interaction: ${customId}`);
+                    if (interaction.isRepliable()) {
+                        await interaction.reply({
+                            content: 'Diese Aktion ist derzeit nicht verfügbar.',
+                            flags: MessageFlags.Ephemeral,
+                        });
+                    }
+                    break;
+            }
+        } catch (err) {
+            logger.error('❌ Fehler in housing interaction:', err);
+            if (interaction.isRepliable()) {
+                const reply = { content: 'Es ist ein Fehler aufgetreten.', flags: MessageFlags.Ephemeral } as const;
+                if (interaction.deferred || interaction.replied) {
+                    await interaction.followUp(reply);
+                } else {
+                    await interaction.reply(reply);
+                }
+            }
+        }
+    });
+}
+
+export default { register };

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,5 +1,6 @@
 import type { Client } from 'discord.js';
 import * as ready from './ready.js';
+import * as housingInteraction from './housing/housingInteraction.js';
 import * as interactionCreate from './interactionCreate.js';
 
 /**
@@ -7,6 +8,7 @@ import * as interactionCreate from './interactionCreate.js';
  */
 export function registerEvents(client: Client) {
     ready.register(client);
+    housingInteraction.register(client);
     interactionCreate.register(client);
 }
 

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,6 +1,7 @@
 import { Events, Client, MessageFlags } from 'discord.js';
 import { logger } from '../lib/logger.js';
 import { commandHandler } from '../lib/command/commandHandler.js';
+import { HOUSING_PREFIX } from '../commands/config/housingConfig.js';
 
 /**
  * Registers the interactionCreate event used to route interactions
@@ -18,6 +19,9 @@ export function register(client: Client) {
                 interaction.isUserSelectMenu() ||
                 interaction.isRoleSelectMenu()
             ) {
+                if (interaction.customId?.startsWith(HOUSING_PREFIX)) {
+                    return;
+                }
                 logger.warn(`Unhandled interaction: ${interaction.customId}`);
                 if (interaction.isRepliable()) {
                     const reply = {


### PR DESCRIPTION
## Summary
- add dedicated housing interaction handler
- register housing interactions and ignore them in fallback handler

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6898edbdff248321bb0b8e88f0166323