### PR TITLE
feat: allow multi-world housing configuration

### DIFF
--- a/src/const/housing/housing.ts
+++ b/src/const/housing/housing.ts
@@ -1,4 +1,4 @@
-export const DATACENTERS = ['Light', 'Chaos', 'Aether', 'Primal', 'Crystal', 'Dynamis', 'Materia', 'Elemental', 'Gaia', 'Mana', 'Meteor'] as const;
+export const DATACENTERS = ['Light', 'Chaos', 'Shadow', 'Aether', 'Primal', 'Crystal', 'Dynamis', 'Materia', 'Elemental', 'Gaia', 'Mana', 'Meteor'] as const;
 
 export const DISTRICT_OPTIONS = [
     { label: 'Mist', value: 'Mist' },

--- a/src/schemas/housing.ts
+++ b/src/schemas/housing.ts
@@ -6,7 +6,7 @@ import type { ConfigSchema } from '../handlers/configSchema.js';
 export const housingPartial = z.object({
     enabled: z.boolean(),
     dataCenter: z.string().min(1).optional(),
-    world: z.string().min(1).optional(),
+    worlds: z.array(z.string().min(1)).optional(),
     districts: z.array(z.string()).optional(),
     channelId: z.string().min(1).optional(),
     timesPerDay: z.number().int().min(1).max(24).optional(),
@@ -20,7 +20,7 @@ export const housingPartial = z.object({
 export const HousingRequired = z.object({
     enabled: z.literal(true),
     dataCenter: z.string().min(1),
-    world: z.string().min(1),
+    worlds: z.array(z.string().min(1)).nonempty(),
     districts: z.array(z.string()).nonempty(),
     channelId: z.string().min(1),
     timesPerDay: z.number().int().min(1).max(24),

--- a/src/ui/housingUI.ts
+++ b/src/ui/housingUI.ts
@@ -5,7 +5,7 @@ type Key = string;
 export type HousingDraft = {
     enabled: boolean;
     dataCenter?: string;
-    world?: string;
+    worlds?: string[];
     districts?: string[];
     channelId?: string;
     timesPerDay?: number;


### PR DESCRIPTION
## Summary
- add Shadow data center and support selecting multiple worlds per DC
- update housing UI and runner to handle multi-world config

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: Cannot find module '../../lib/config/configHandler')

------
https://chatgpt.com/codex/tasks/task_b_68ad808da2b48321be4307185fa445b9