### PR TITLE
feat: auto-save housing config

### DIFF
--- a/src/commands/config/housingConfig.ts
+++ b/src/commands/config/housingConfig.ts
@@ -96,12 +96,14 @@ async function handle(interaction: ChatInputCommandInteraction) {
     );
 
   // Channel picker
-  const chRow = new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(
-    new ChannelSelectMenuBuilder()
-      .setCustomId(PREFIX + "channel")
-      .setPlaceholder("Zielkanal")
-      .addChannelTypes(ChannelType.GuildText),
-  );
+  const chBuilder = new ChannelSelectMenuBuilder()
+    .setCustomId(PREFIX + "channel")
+    .setPlaceholder("Zielkanal")
+    .addChannelTypes(ChannelType.GuildText)
+    .setMinValues(0)
+    .setMaxValues(1);
+  if (h.channelId) chBuilder.setDefaultChannels(h.channelId);
+  const chRow = new ActionRowBuilder<ChannelSelectMenuBuilder>().addComponents(chBuilder);
 
   // User mention picker
   const userBuilder = new UserSelectMenuBuilder()
@@ -131,10 +133,6 @@ async function handle(interaction: ChatInputCommandInteraction) {
       .setCustomId(PREFIX + "schedule")
       .setLabel("Schedule…")
       .setStyle(ButtonStyle.Secondary),
-    new ButtonBuilder()
-      .setCustomId(PREFIX + "save")
-      .setLabel("Save")
-      .setStyle(ButtonStyle.Primary),
     new ButtonBuilder()
       .setCustomId(PREFIX + "cancel")
       .setLabel("Cancel")


### PR DESCRIPTION
## Summary
- remove explicit save button from housing configuration UI
- persist housing changes automatically whenever options are modified
- refresh option menus to reflect current selections

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ada59fb0e883219d311f3e7ac056d7