### PR TITLE
Fix housing research command for inline selection

### DIFF
--- a/src/commands/housing/housingResearch.ts
+++ b/src/commands/housing/housingResearch.ts
@@ -13,16 +13,13 @@ import { DATACENTERS, DISTRICT_OPTIONS } from '../../const/housing/housing';
 
 const builder = new SlashCommandSubcommandBuilder()
     .setName('research')
-    .setDescription('Recherchiere interaktiv in einer DM')
+    .setDescription('Recherchiere interaktiv im Chat')
 
 export default {
     name: builder.name,
     description: builder.description,
     async execute(interaction: ChatInputCommandInteraction) {
         if (interaction.options.getSubcommand(true) !== builder.name) return;
-
-        await interaction.reply({ content: 'Ich habe dir eine DM Geschickt', flags: MessageFlags.Ephemeral });
-        const dm = await interaction.user.createDM();
 
         const dcRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
             new StringSelectMenuBuilder()
@@ -37,8 +34,14 @@ export default {
             new StringSelectMenuBuilder()
                 .setCustomId('research:world')
                 .setPlaceholder('Welt wählen')
+                .addOptions(
+                    new StringSelectMenuOptionBuilder()
+                        .setLabel('Bitte Datacenter wählen')
+                        .setValue('placeholder'),
+                )
                 .setMinValues(1)
-                .setMaxValues(1),
+                .setMaxValues(1)
+                .setDisabled(true),
         );
 
         const distRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
@@ -84,6 +87,10 @@ export default {
                 .setStyle(ButtonStyle.Primary),
         );
 
-        await dm.send({ content: 'Housing Research - wähle Filter:', components: [dcRow, worldRow, distRow, fcRow, sizeRow, goRow]});
+        await interaction.reply({
+            content: 'Housing Research - wähle Filter:',
+            components: [dcRow, worldRow, distRow, fcRow, sizeRow, goRow],
+            flags: MessageFlags.Ephemeral,
+        });
     },
 };


### PR DESCRIPTION
## Summary
- send housing research filters directly in interaction reply instead of DM
- add disabled world selector with placeholder option

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b41e49078883218a4ea2c3900dd0d8