### PR TITLE
feat: add housing schedule configuration

### DIFF
--- a/src/commands/housing/housingRefresh.ts
+++ b/src/commands/housing/housingRefresh.ts
@@ -11,7 +11,11 @@ export default {
       return;
     }
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-    const { added, removed, updated } = await refreshHousing(interaction.client, guildID);
-    await interaction.editReply({ content: `Housing refreshed. ${added} added, ${removed} removed, ${updated} updated.` });
+    const { added, removed, updated, elapsedMs = 0 } = await refreshHousing(interaction.client, guildID);
+    const secs = Math.floor(elapsedMs / 1000);
+    const hh = String(Math.floor(secs / 3600)).padStart(2, '0');
+    const mm = String(Math.floor((secs % 3600) / 60)).padStart(2, '0');
+    const ss = String(secs % 60).padStart(2, '0');
+    await interaction.editReply({ content: `Housing refreshed in ${hh}:${mm}:${ss}. ${added} added, ${removed} removed, ${updated} updated.` });
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { commands } from './handlers/commandInit.js';
 import { commandHandler } from './handlers/commandHandler.js';
 import { registerEvents } from './events/index.js';
 import { startHousingMessageWatcher } from './watchers/housingMessageWatcher.js';
+import { startHousingScheduler } from './functions/housing/housingScheduler.js';
 import { botConfig } from './config.js';
 
 // Ensure the Discord token is available. Without it the bot cannot start.
@@ -29,6 +30,7 @@ commandHandler.registerAll(commands);
 // Set up event listeners.
 registerEvents(client);
 startHousingMessageWatcher(client);
+startHousingScheduler(client);
 
 // Finally log in using the provided token. Any login failure is fatal.
 client.login(token).catch((e) => {


### PR DESCRIPTION
## Summary
- add interactive schedule configuration for housing feature
- start recurring housing refresh scheduler on bot startup
- refine housing refresh to update, remove, or create listings based on Paissa API and report duration

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b6e0a5ca4c83218b2b959631cc7b60