### PR TITLE
fix: persist housing refresh state

### DIFF
--- a/src/functions/housing/housingRefresh.ts
+++ b/src/functions/housing/housingRefresh.ts
@@ -1,7 +1,7 @@
 import { Client, ForumChannel, ChannelType, ThreadChannel } from 'discord.js';
 import type { TextBasedChannel } from 'discord.js';
 import path from 'node:path';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { logger } from '../../lib/logger.js';
 import { configManager } from '../../handlers/configHandler.js';
 import { HousingRequired } from '../../schemas/housing.js';
@@ -361,6 +361,7 @@ export async function refreshHousing(client: Client, guildID: string) {
 /** Safe write helper mit Logging */
 async function writeSafe(fp: string, store: Record<string, MsgRecord>, guildId: string) {
   try {
+    await mkdir(path.dirname(fp), { recursive: true });
     await writeFile(fp, JSON.stringify(store, null, 2), 'utf8');
     logger.info(
       `[🏠Housing][${guildId}] State gespeichert (${fp}) | threads=${Object.keys(store[guildId]?.threads ?? {}).length} messages=${Object.keys(store[guildId]?.messages ?? {}).length}`

--- a/src/functions/housing/housingScheduler.ts
+++ b/src/functions/housing/housingScheduler.ts
@@ -3,7 +3,7 @@ import { configManager } from '../../handlers/configHandler';
 import { HousingRequired } from '../../schemas/housing';
 import { refreshHousing } from './housingRefresh';
 import { logError } from '../../handlers/errorHandler.js';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 
 type S = { last?: number; runs: number; day: string; running: boolean };
@@ -32,6 +32,7 @@ async function saveState() {
         obj[gid] = rec;
     }
     try {
+        await mkdir(path.dirname(stateFile), { recursive: true });
         await writeFile(stateFile, JSON.stringify(obj, null, 2), 'utf8');
     } catch (err) {
         logError('housing scheduler state save', err);

--- a/src/watchers/housingMessageWatcher.ts
+++ b/src/watchers/housingMessageWatcher.ts
@@ -1,5 +1,5 @@
 import { messageLink, type Client, ChannelType, type TextBasedChannel } from 'discord.js';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { logger } from '../lib/logger';
 
@@ -112,6 +112,7 @@ export function startHousingMessageWatcher(client: Client) {
       // 3) Store zurückschreiben (nur wenn Änderungen)
       if (changed) {
         try {
+          await mkdir(path.dirname(filePath), { recursive: true });
           await writeFile(filePath, JSON.stringify(store, null, 2), 'utf8');
           logger.info(`Änderungen am Store gespeichert: removed=${removed}, checked=${checked}`);
         } catch (err) {


### PR DESCRIPTION
## Summary
- ensure housing refresh creates storage directory before saving state
- harden watcher and scheduler persistence against missing directories

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b9814d0cfc8321b3a086f4c0a2f506