### PR TITLE
Normalize housing keys to prevent duplicate refresh entries

### DIFF
--- a/src/functions/housing/housingRefresh.ts
+++ b/src/functions/housing/housingRefresh.ts
@@ -21,8 +21,18 @@ type MsgRecord = {
 const provider = new PaissaProvider();
 const filePath = path.join(process.cwd(), 'src', 'json', 'housing_messages.json');
 
+function normDistrict(d: string): string {
+  return d.replace(/^the\s+/i, '').trim().toLowerCase();
+}
+
 function plotKey(p: Plot): string {
-  return [p.dataCenter, p.world, p.district, p.ward, p.plot].join(':');
+  return [
+    p.dataCenter.toLowerCase(),
+    p.world.toLowerCase(),
+    normDistrict(p.district),
+    p.ward,
+    p.plot
+  ].join(':');
 }
 
 function plotHash(p: Plot): string {

--- a/src/functions/housing/housingSaveConfig.ts
+++ b/src/functions/housing/housingSaveConfig.ts
@@ -35,6 +35,18 @@ export async function add(g: string, key: string) {
     }
 }
 
+function norm(v: string) {
+    return v.replace(/^the\s+/i, '').trim().toLowerCase();
+}
+
 export function makeKey(p: { dataCenter: string; world: string; district: string; ward: number; plot: number; lottery: { state: string; endsAt?: string}}) {
-    return [p.dataCenter, p.world, p.district, p.ward, p.plot, p.lottery.state, p.lottery.endsAt ?? ''].join(':');
+    return [
+        norm(p.dataCenter),
+        norm(p.world),
+        norm(p.district),
+        p.ward,
+        p.plot,
+        p.lottery.state,
+        p.lottery.endsAt ?? ''
+    ].join(':');
 }


### PR DESCRIPTION
## Summary
- Normalize datacenter, world, and district names when creating housing plot keys
- Use normalized keys for storing seen housing plots

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b988f0e2a48321843f55fcd5d9d49e