### PR TITLE
feat: filter expired housing plots and improve help listings

### DIFF
--- a/src/commands/config/config.ts
+++ b/src/commands/config/config.ts
@@ -33,4 +33,4 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     await entry.execute(interaction);
 }
 
-export default { data, execute };
+export default { data, execute, emoji: '⚙️' };

--- a/src/commands/help/help.ts
+++ b/src/commands/help/help.ts
@@ -14,20 +14,23 @@ const command: Command = {
         // Import the command list at runtime to avoid circular deps during module load.
         const { commands } = await import('../../handlers/commandInit.js');
 
-        const embed = new EmbedBuilder()
-            .setTitle('Verfügbare Befehle');
+        const sorted = [...commands].sort((a, b) => a.data.name.localeCompare(b.data.name));
+        const embed = new EmbedBuilder().setTitle('Verfügbare Befehle');
 
-
-        // Add each known command to the embed so users can see what exists.
-        for (const cmd of commands.slice(0, 25)) {
-            embed.addFields({ name: `/${cmd.data.name}`, value: cmd.data.description || 'Keine Beschreibung' });
+        for (const cmd of sorted.slice(0, 25)) {
+            const emoji = cmd.emoji ?? '❔';
+            embed.addFields({
+                name: `${emoji} /${cmd.data.name}`,
+                value: cmd.data.description || 'Keine Beschreibung',
+            });
         }
 
-        await interaction.reply({ 
-            embeds: [embed], 
+        await interaction.reply({
+            embeds: [embed],
             flags: MessageFlags.Ephemeral,
         });
     },
+    emoji: '❓',
 };
 
 export default command;

--- a/src/commands/housing/housing.ts
+++ b/src/commands/housing/housing.ts
@@ -11,6 +11,7 @@ import type { Command } from "../../handlers/commandHandler";
 import setup from './housingSetup';
 import refresh from './housingRefresh';
 import research from './housingResearch';
+import info from './housingInfo';
 
 type Sub = {
     name: string;
@@ -20,7 +21,7 @@ type Sub = {
     autocomplete?: (interaction: AutocompleteInteraction) => Promise<void>;
 };
 
-const SUBS: Sub[] = [setup, refresh, research];
+const SUBS: Sub[] = [setup, refresh, research, info];
 
 export const data = (() => {
     const command = new SlashCommandBuilder()
@@ -53,4 +54,4 @@ export async function autocomplete(interaction: AutocompleteInteraction) {
     await entry.autocomplete(interaction);
 }
 
-export default { data, execute, autocomplete } satisfies Command;
+export default { data, execute, autocomplete, emoji: '🏠' } satisfies Command;

--- a/src/commands/housing/housingInfo.ts
+++ b/src/commands/housing/housingInfo.ts
@@ -1,0 +1,12 @@
+import { MessageFlags, type ChatInputCommandInteraction } from 'discord.js';
+
+export default {
+  name: 'info',
+  description: 'Information about housing data and limitations',
+  async execute(interaction: ChatInputCommandInteraction) {
+    const content =
+      'Provides housing plot listings using the PaissaDB API. ' +
+      'Data may be incomplete and not always match in-game status 1:1, so some posted plots could be inaccurate.';
+    await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+  },
+};

--- a/src/commands/housing/housingSetup.ts
+++ b/src/commands/housing/housingSetup.ts
@@ -201,8 +201,13 @@ export default {
       'housing:setup',
       async () => {
         const plots = [] as Awaited<ReturnType<typeof provider.fetchFreePlots>>;
+        const now = Date.now();
         for (const world of hc.worlds) {
-          const p = await provider.fetchFreePlots(hc.dataCenter, world, hc.districts);
+          const p = await provider
+            .fetchFreePlots(hc.dataCenter, world, hc.districts)
+            .then(list =>
+              list.filter(pl => !(pl.lottery?.phaseUntil && pl.lottery.phaseUntil <= now)),
+            );
           plots.push(...p);
         }
 

--- a/src/functions/housing/housingRefresh.ts
+++ b/src/functions/housing/housingRefresh.ts
@@ -171,10 +171,12 @@ export async function refreshHousing(client: Client, guildID: string) {
     return { added: 0, removed, updated: 0 };
   }
 
+  const nowMs = Date.now();
   for (const world of worlds) {
     try {
       const p = await provider.fetchFreePlots(hc.dataCenter, world, hc.districts);
-      allPlots.push(...p);
+      const valid = p.filter(pl => !(pl.lottery?.phaseUntil && pl.lottery.phaseUntil <= nowMs));
+      allPlots.push(...valid);
     } catch (e: any) {
       logger.error(`[🏠Housing][${guildID}] Provider-Fehler (world=${world}): ${String(e)}`);
     }

--- a/src/handlers/commandHandler.ts
+++ b/src/handlers/commandHandler.ts
@@ -18,6 +18,8 @@ export interface Command {
     execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
     /** Optional handler for autocomplete interactions. */
     autocomplete?: (interaction: AutocompleteInteraction) => Promise<void>;
+    /** Optional emoji shown in help listings. */
+    emoji?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- avoid posting expired housing plots during setup and refresh
- add `/housing info` command with API details and disclaimer
- extend help command to list commands alphabetically with emojis

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b9bde8192483219f7c6fed77303f83