### PR TITLE
Filter expired housing plots from research results

### DIFF
--- a/src/commands/housing/housingResearch.ts
+++ b/src/commands/housing/housingResearch.ts
@@ -99,7 +99,10 @@ export default {
     const districts = splitCommalist(districtsStr);
     const start = Date.now();
     const plots = await provider.fetchFreePlots(dc, world, districts);
-    let filtered = plots;
+    const now = Date.now();
+    let filtered = plots.filter(
+      p => p.ward > 0 && (p.lottery.phaseUntil === undefined || p.lottery.phaseUntil > now),
+    );
     if (fc !== 'beides') {
       const want = fc === 'ja';
       filtered = filtered.filter(p => p.fcOnly === want);


### PR DESCRIPTION
## Summary
- skip housing research results when the plot lottery has expired
- exclude plots in ward 0 from research

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bab03b26cc8321afc4a8532c82fef5